### PR TITLE
[FEATURE] Implemented state pattern

### DIFF
--- a/Composite/LightElementNode.php
+++ b/Composite/LightElementNode.php
@@ -2,24 +2,51 @@
 
 namespace Composite;
 
+use Composite\State\VisibilityStateInterface;
+use Composite\State\VisibleState;
+
 class LightElementNode extends LightNode {
     private MetaDataFlyweight $flyweight;
     private array $cssClasses = [];
     private array $children = [];
+    private VisibilityStateInterface $state;
 
     public function __construct(string $tagName, string $displayType = 'block', string $closingType = 'pair') {
         $this->flyweight = MetaDataFlyweightFactory::getFlyweight($tagName, $displayType, $closingType);
+        $this->state = new VisibleState();
     }
 
     public function addClass(string $className): void {
         $this->cssClasses[] = $className;
     }
 
+    public function getCssClasses(): array
+    {
+        return $this->cssClasses;
+    }
+
     public function addChild(LightNode $child): void {
         $this->children[] = $child;
     }
 
+    public function getOuterHTML(): string {
+        return $this->state->getOuterHTML($this);
+    }
+
     public function getInnerHTML(): string {
+        return $this->state->getInnerHTML($this);
+    }
+
+    public function getChildrenCount(): int {
+        return count($this->children);
+    }
+
+    public function getFlyweight(): MetaDataFlyweight
+    {
+        return $this->flyweight;
+    }
+
+    public function generateInnerHTML(): string {
         $html = '';
         foreach ($this->children as $child) {
             $html .= $child->getOuterHTML();
@@ -27,20 +54,8 @@ class LightElementNode extends LightNode {
         return $html;
     }
 
-    public function getOuterHTML(): string {
-        $tagName = $this->flyweight->tagName;
-        $closingType = $this->flyweight->closingType;
-
-        $classAttr = empty($this->cssClasses) ? '' : ' class="' . implode(' ', $this->cssClasses) . '"';
-
-        if ($closingType === 'single') {
-            return "<{$tagName}{$classAttr} />";
-        }
-
-        return "<{$tagName}{$classAttr}>" . $this->getInnerHTML() . "</{$tagName}>";
-    }
-
-    public function getChildrenCount(): int {
-        return count($this->children);
+    public function setState(VisibilityStateInterface $state): void
+    {
+        $this->state = $state;
     }
 }

--- a/Composite/State/CollapsedState.php
+++ b/Composite/State/CollapsedState.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Composite\State;
+
+use Composite\LightElementNode;
+
+class CollapsedState implements VisibilityStateInterface
+{
+    public function getOuterHTML(LightElementNode $context): string {
+        $tagName = $context->getFlyweight()->tagName;
+        $classAttr = empty($context->getCssClasses()) ? '' : ' class="' . implode(' ', $context->getCssClasses()) . '"';
+        return "<{$tagName} {$classAttr}></{$tagName}>";
+    }
+
+    public function getInnerHTML(LightElementNode $context): string {
+        return '';
+    }
+
+}

--- a/Composite/State/HiddenState.php
+++ b/Composite/State/HiddenState.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Composite\State;
+
+use Composite\LightElementNode;
+
+class HiddenState implements VisibilityStateInterface
+{
+    public function getOuterHTML(LightElementNode $context): string {
+        return '';
+    }
+
+    public function getInnerHTML(LightElementNode $context): string {
+        return '';
+    }
+
+}

--- a/Composite/State/VisibilityStateInterface.php
+++ b/Composite/State/VisibilityStateInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Composite\State;
+
+use Composite\LightElementNode;
+
+interface VisibilityStateInterface
+{
+    public function getOuterHTML(LightElementNode $context): string;
+    public function getInnerHTML(LightElementNode $context): string;
+
+}

--- a/Composite/State/VisibleState.php
+++ b/Composite/State/VisibleState.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Composite\State;
+
+use Composite\LightElementNode;
+
+class VisibleState implements VisibilityStateInterface
+{
+    public function getOuterHTML(LightElementNode $context): string {
+        $tagName = $context->getFlyweight()->tagName;
+        $innerHTML = $context->getInnerHTML();
+
+        $classAttr = empty($context->getCssClasses()) ? '' : ' class="' . implode(' ', $context->getCssClasses()) . '"';
+
+        if ($context->getFlyweight()->closingType === 'single') {
+            return "<{$tagName}{$classAttr} />";
+        }
+
+        return "<{$tagName}{$classAttr}>" . $innerHTML . "</{$tagName}>";
+    }
+
+    public function getInnerHTML(LightElementNode $context): string {
+        return $context->generateInnerHTML();
+    }
+
+}

--- a/index.php
+++ b/index.php
@@ -148,17 +148,19 @@ function convertTextToLightHTML(string $text): LightElementNode {
 }
 
 
-$bookText = file_get_contents('Composite/book.txt');
+//$bookText = file_get_contents('Composite/book.txt');
+//
+//$startMemory = memory_get_usage();
+//
+//$lightHTML = convertTextToLightHTML($bookText);
+//$output =  $lightHTML->getOuterHTML();
+//
+//$endMemory = memory_get_usage();
+//
+//echo "\n\nВикористано памʼяті: " . round(($endMemory - $startMemory) / 1024) .  " KB";
+//echo "\nУнікальних flyweight обʼєктів: " . MetaDataFlyweightFactory::getCount() . "\n";
+//
+//echo $output;
 
-$startMemory = memory_get_usage();
-
-$lightHTML = convertTextToLightHTML($bookText);
-$output =  $lightHTML->getOuterHTML();
-
-$endMemory = memory_get_usage();
-
-echo "\n\nВикористано памʼяті: " . round(($endMemory - $startMemory) / 1024) .  " KB";
-echo "\nУнікальних flyweight обʼєктів: " . MetaDataFlyweightFactory::getCount() . "\n";
-
-echo $output;
+require_once "lighthtml.php";
 

--- a/lighthtml.php
+++ b/lighthtml.php
@@ -1,0 +1,23 @@
+<?php
+
+use Composite\LightElementNode;
+use Composite\LightTextNode;
+use Composite\State\CollapsedState;
+use Composite\State\HiddenState;
+use Composite\State\VisibleState;
+
+$div = new LightElementNode('div');
+$div->addClass('container');
+$div->addChild(new LightTextNode('State test!'));
+
+// expected - empty
+$div->setState(new HiddenState());
+echo $div->getOuterHTML();
+
+// expected - <div class="container">State test!</div>
+$div->setState(new VisibleState());
+echo $div->getOuterHTML();
+
+// expected - <div class="container"></div>
+$div->setState(new CollapsedState());
+echo $div->getOuterHTML();


### PR DESCRIPTION
Created state logic: visible - normal output, hidden - empty string, collapsed - element without inner part. Implemented three classes of their own state logic [VisibleState](https://github.com/merelythesame/kpz-labs/blob/feature-state/Composite/State/VisibleState.php), [HiddenState](https://github.com/merelythesame/kpz-labs/blob/feature-state/Composite/State/HiddenState.php), [CollapsedState](https://github.com/merelythesame/kpz-labs/blob/feature-state/Composite/State/CollapsedState.php) that implement [VisibilityStateInterface](https://github.com/merelythesame/kpz-labs/blob/feature-state/Composite/State/VisibilityStateInterface.php). In [LightElementNode](https://github.com/merelythesame/kpz-labs/blob/feature-state/Composite/LightElementNode.php)  state is determined by corresponding field and function getInnerHtml(), getOuterHtml() delegate logic to concrete implementations. 