### PR TITLE
[FEATURE] Implemented visitor pattern

### DIFF
--- a/Composite/LightElementNode.php
+++ b/Composite/LightElementNode.php
@@ -4,8 +4,7 @@ namespace Composite;
 
 use Composite\State\VisibilityStateInterface;
 use Composite\State\VisibleState;
-use Composite\Template\MarkDownSerializer;
-use Composite\Template\Serializer;
+use Composite\Visitor\NodeVisitorInterface;
 
 class LightElementNode extends LightNode {
     private MetaDataFlyweight $flyweight;
@@ -53,6 +52,10 @@ class LightElementNode extends LightNode {
             $html .= $child->getOuterHTML();
         }
         return $html;
+    }
+
+    public function accept(NodeVisitorInterface $visitor, int $depth = 1): void {
+        $visitor->visitElementNode($this, $depth);
     }
 
     public function setState(VisibilityStateInterface $state): void

--- a/Composite/LightNode.php
+++ b/Composite/LightNode.php
@@ -2,7 +2,10 @@
 
 namespace Composite;
 
+use Composite\Visitor\NodeVisitorInterface;
+
 abstract class LightNode {
     abstract public function getOuterHTML(): string;
     abstract public function getInnerHTML(): string;
+    abstract public function accept(NodeVisitorInterface $visitor, int $depth = 1): void;
 }

--- a/Composite/LightTextNode.php
+++ b/Composite/LightTextNode.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Composite;
+use Composite\Visitor\NodeVisitorInterface;
 
 class LightTextNode extends LightNode {
     private string $text;
@@ -15,5 +16,9 @@ class LightTextNode extends LightNode {
 
     public function getInnerHTML(): string {
         return $this->getOuterHTML();
+    }
+
+    public function accept(NodeVisitorInterface $visitor, int $depth = 1): void {
+        $visitor->visitTextNode($this);
     }
 }

--- a/Composite/Visitor/NodeVisitorInterface.php
+++ b/Composite/Visitor/NodeVisitorInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Composite\Visitor;
+
+use Composite\LightElementNode;
+use Composite\LightTextNode;
+
+interface NodeVisitorInterface
+{
+    public function visitTextNode(LightTextNode $node): void;
+    public function visitElementNode(LightElementNode $node, int $depth = 1): void;
+}

--- a/Composite/Visitor/TagDepthTrackerVisitor.php
+++ b/Composite/Visitor/TagDepthTrackerVisitor.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Composite\Visitor;
+
+use Composite\LightTextNode;
+use Composite\LightElementNode;
+
+class TagDepthTrackerVisitor implements NodeVisitorInterface
+{
+    private int $maxDepth = 0;
+    private array $depthCounts = [];
+
+    public function visitTextNode(LightTextNode $node): void {
+
+    }
+
+    public function visitElementNode(LightElementNode $node, int $depth = 1): void {
+        if ($depth > $this->maxDepth) {
+            $this->maxDepth = $depth;
+        }
+
+        if (!isset($this->depthCounts[$depth])) {
+            $this->depthCounts[$depth] = 0;
+        }
+        $this->depthCounts[$depth]++;
+
+        foreach ($node->getChildren() as $child) {
+            $child->accept($this, $depth + 1);
+        }
+    }
+
+    public function getMaxDepth(): int {
+        return $this->maxDepth;
+    }
+
+    public function getDepthCounts(): array {
+        return $this->depthCounts;
+    }
+
+}

--- a/lighthtml.php
+++ b/lighthtml.php
@@ -7,6 +7,10 @@ use Composite\State\HiddenState;
 use Composite\State\VisibleState;
 use Composite\Template\JsonSerializer;
 use Composite\Template\MarkDownSerializer;
+use Composite\Visitor\TagDepthTrackerVisitor;
+
+
+echo "<h2>State</h2>";
 
 $div = new LightElementNode('div');
 $div->addClass('container');
@@ -24,6 +28,7 @@ echo $div->getOuterHTML();
 $div->setState(new CollapsedState());
 echo $div->getOuterHTML();
 
+echo "<h2>Template</h2>";
 
 $div = new LightElementNode('div');
 $h1 = new LightElementNode('h1');
@@ -35,3 +40,27 @@ echo $JsonSerializer->serialize($div);
 
 $MarkDownSerializer = new MarkDownSerializer();
 echo $MarkDownSerializer->serialize($div);
+
+
+echo "<h2>Visitor</h2>";
+
+$div = new LightElementNode('div');
+$section = new LightElementNode('section');
+$article = new LightElementNode('article');
+$p = new LightElementNode('p');
+$p->addChild(new LightTextNode('Hello'));
+
+$article->addChild($p);
+$section->addChild($article);
+$div->addChild($section);
+
+echo $div->getOuterHTML();
+
+$visitor = new TagDepthTrackerVisitor();
+$div->accept($visitor);
+
+echo "Max tag depth: " . $visitor->getMaxDepth() . "<br>";
+echo "Nodes per depth level:" . "<br>";
+foreach ($visitor->getDepthCounts() as $depth => $count) {
+    echo "Depth $depth: $count node(s)" . "<br>";
+}


### PR DESCRIPTION
- [TagDepthTrackerVisitor](https://github.com/merelythesame/kpz-labs/blob/feature-visitor/Composite/Visitor/TagDepthTrackerVisitor.php) implemented the Visitor pattern for traversing the LightHTML tree, tracking the maximum depth of tags in the DOM structure, counting the number of elements at each level of nesting. 

- Updated the [LightNode](https://github.com/merelythesame/kpz-labs/blob/feature-visitor/Composite/LightNode.php), [LightElementNode](https://github.com/merelythesame/kpz-labs/blob/feature-visitor/Composite/LightElementNode.php), and [LightTextNode](https://github.com/merelythesame/kpz-labs/blob/feature-visitor/Composite/LightTextNode.php) nodes with support for the accept() method for working with visitors.