### PR TITLE
[FEATURE] Implemented command pattern

### DIFF
--- a/Composite/Command/ClearContentCommand.php
+++ b/Composite/Command/ClearContentCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Composite\Command;
+
+use Composite\LightElementNode;
+
+class ClearContentCommand implements CommandInterface
+{
+    private LightElementNode $target;
+    private array $backup = [];
+    private bool $executed = false;
+
+    public function __construct(LightElementNode $target) {
+        $this->target = $target;
+    }
+
+    public function execute(): void {
+        if (!$this->executed) {
+            $this->backup = $this->target->getChildren();
+            $this->target->clearChildren();
+            $this->executed = true;
+        }
+    }
+
+    public function undo(): void {
+        if ($this->executed) {
+            foreach ($this->backup as $child) {
+                $this->target->addChild($child);
+            }
+            $this->executed = false;
+        }
+    }
+
+    public function isExecuted(): bool {
+        return $this->executed;
+    }
+
+}

--- a/Composite/Command/CommandInterface.php
+++ b/Composite/Command/CommandInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Composite\Command;
+
+interface CommandInterface
+{
+    public function execute(): void;
+}

--- a/Composite/LightElementNode.php
+++ b/Composite/LightElementNode.php
@@ -2,6 +2,8 @@
 
 namespace Composite;
 
+use Composite\Command\ClearContentCommand;
+use Composite\Command\CommandInterface;
 use Composite\State\VisibilityStateInterface;
 use Composite\State\VisibleState;
 use Composite\Visitor\NodeVisitorInterface;
@@ -11,6 +13,8 @@ class LightElementNode extends LightNode {
     private array $cssClasses = [];
     private array $children = [];
     private VisibilityStateInterface $state;
+    private CommandInterface $command;
+
     public function __construct(string $tagName, string $displayType = 'block', string $closingType = 'pair') {
         $this->flyweight = MetaDataFlyweightFactory::getFlyweight($tagName, $displayType, $closingType);
         $this->state = new VisibleState();
@@ -27,6 +31,15 @@ class LightElementNode extends LightNode {
 
     public function addChild(LightNode $child): void {
         $this->children[] = $child;
+    }
+
+    public function getChildren(): array
+    {
+        return $this->children;
+    }
+
+    public function clearChildren(): void {
+        $this->children = [];
     }
 
     public function getOuterHTML(): string {
@@ -63,8 +76,22 @@ class LightElementNode extends LightNode {
         $this->state = $state;
     }
 
-    public function getChildren(): array
+    public function setCommand(CommandInterface $command): void
     {
-        return $this->children;
+        $this->command = $command;
+    }
+
+    public function executeCommand(): void
+    {
+        if ($this->command instanceof ClearContentCommand) {
+            if ($this->command->isExecuted()) {
+                $this->command->undo();
+            } else {
+                $this->command->execute();
+            }
+        } else {
+            $this->command?->execute();
+        }
+
     }
 }

--- a/lighthtml.php
+++ b/lighthtml.php
@@ -1,5 +1,6 @@
 <?php
 
+use Composite\Command\ClearContentCommand;
 use Composite\LightElementNode;
 use Composite\LightTextNode;
 use Composite\State\CollapsedState;
@@ -64,3 +65,26 @@ echo "Nodes per depth level:" . "<br>";
 foreach ($visitor->getDepthCounts() as $depth => $count) {
     echo "Depth $depth: $count node(s)" . "<br>";
 }
+
+echo "<h2>Command</h2>";
+
+$div = new LightElementNode('div');
+$p = new LightElementNode('p');
+$p->addChild(new LightTextNode('Old text'));
+$div->addChild($p);
+
+$button = new LightElementNode('button');
+$button->addChild(new LightTextNode('Clear Content'));
+
+$clearCommand = new ClearContentCommand($div);
+$button->setCommand($clearCommand);
+
+echo "First:" . htmlspecialchars($div->getOuterHTML()) . "<br>";
+
+$button->executeCommand();
+
+echo "Clean:" . htmlspecialchars($div->getOuterHTML()) . "<br>";
+
+$button->executeCommand();
+
+echo "Undone:" . htmlspecialchars($div->getOuterHTML()) . "<br>";


### PR DESCRIPTION
- Added a new feature for LightHTML, implemented using the Command pattern. 

- Created the [ClearContentCommand](https://github.com/merelythesame/kpz-labs/blob/feature-command/Composite/Command/ClearContentCommand.php) class, which allows you to clear the content of a [LightElementNode](https://github.com/merelythesame/kpz-labs/blob/feature-command/Composite/LightElementNode.php).

- Implemented the [undo()](https://github.com/merelythesame/kpz-labs/blob/feature-command/Composite/Command/ClearContentCommand.php#L25-L32) method, which restores the previous content of the element after clearing. 

- Added support for executing and undoing a command via the [executeCommand()](https://github.com/merelythesame/kpz-labs/blob/feature-command/Composite/LightElementNode.php#L84-L96) method in [LightElementNode](https://github.com/merelythesame/kpz-labs/blob/feature-command/Composite/LightElementNode.php)